### PR TITLE
Add cosign keyless signing to Docker image release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ env:
 permissions:
   contents: write
   packages: write
+  id-token: write
 
 jobs:
   create-release:
@@ -229,6 +230,7 @@ jobs:
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker image
+        id: build-and-push
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -240,5 +242,10 @@ jobs:
             ghcr.io/haasonsaas/diffscope:latest
             ghcr.io/haasonsaas/diffscope:${{ steps.get_version.outputs.VERSION }}
 
-  # Homebrew formula update can be added later when tap repository is created
-  # For now, users can use the install script or download binaries directly
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign image (keyless)
+        env:
+          IMAGE_REF: ghcr.io/haasonsaas/diffscope@${{ steps.build-and-push.outputs.digest }}
+        run: cosign sign --yes "${IMAGE_REF}"


### PR DESCRIPTION
## Summary
- Adds Sigstore cosign keyless signing to the Docker image build step in the release workflow
- Adds `id-token: write` permission for GitHub Actions OIDC token (required for keyless signing)
- Signs `ghcr.io/haasonsaas/diffscope` after push using the build digest

This enables Kyverno image signature verification in the homelab-k8s cluster (see haasonsaas/homelab-k8s#455).

## Test plan
- [ ] Next tag push triggers release workflow with signing step
- [ ] `cosign verify` succeeds against the signed image

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/haasonsaas/diffscope/pull/5" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
