### PR TITLE
Fix HIGH severity Prototype Pollution in flatted (CVE-2026-33228)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -3867,9 +3867,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.0.tgz",
-      "integrity": "sha512-kC6Bb+ooptOIvWj5B63EQWkF0FEnNjV2ZNkLMLZRDDduIiWeFF4iKnslwhiWxjAdbg4NzTNo6h0qLuvFrcx+Sw==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },

--- a/web/package.json
+++ b/web/package.json
@@ -34,6 +34,9 @@
     "recharts": "^3.8.0",
     "tailwindcss": "^4.2.1"
   },
+  "overrides": {
+    "flatted": ">=3.4.2"
+  },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
     "@types/node": "^24.10.1",


### PR DESCRIPTION
## Summary

- Fixes Dependabot alert for **flatted** Prototype Pollution via `parse()` (CVE-2026-33228, HIGH severity)
- `flatted` is a transitive dependency (via `flat-cache` -> `eslint`), pinned at 3.4.0 in the lockfile
- Added an npm `overrides` entry in `web/package.json` to enforce `flatted >=3.4.2`, updating the lockfile from 3.4.0 to 3.4.2

## Test plan

- [x] `npm install --package-lock-only` succeeds without errors
- [x] Verified `flatted` resolves to 3.4.2 in the updated lockfile
- [ ] CI passes (no runtime changes, dev-only transitive dependency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)