### PR TITLE
ci: skip redundant image publishes

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -6,10 +6,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
 
 concurrency:
   group: publish-image-main
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build-and-push:


### PR DESCRIPTION
## Summary
- Skip `Publish image` for docs/Markdown-only main pushes.
- Cancel superseded main publish runs so only the latest image publish continues.

## Evidence
Recent GitHub Actions timing showed DiffScope `Publish image` at 21 sampled main-push runs and ~177 workflow-minutes, with Docker publish jobs commonly taking 8-12 minutes. Docs-only merges do not need to rebuild the image used by PR review automation.

## Validation
- `git diff --check`
- `actionlint .github/workflows/publish-image.yml`