### PR TITLE
Fix Docker build after build script addition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /app
 
 # Cache dependencies
 COPY Cargo.toml Cargo.lock ./
+COPY build.rs ./build.rs
 COPY migrations ./migrations
 RUN mkdir src && echo 'fn main() {}' > src/main.rs && \
     mkdir -p web/dist && \


### PR DESCRIPTION
## Summary

- Copy `build.rs` into the Docker builder dependency-cache layer before the warm-up `cargo build`.

## Why

The post-merge `Publish image` workflow for PR #101 failed because the Docker cache layer runs `cargo build --release` after copying only `Cargo.toml`, `Cargo.lock`, and `migrations`. Since PR #101 added `build = "build.rs"`, Cargo expects `build.rs` during that warm-up build.

## Validation

- `git diff --check`
- `docker build --target builder -t diffscope-buildrs-hotfix:local .` progressed past the previously failing dependency-cache layer; local Colima later OOMed during the final optimized musl link.
- Pre-push hook passed: workflow validation, Cargo version check, `cargo fmt --check`, `cargo clippy --all-targets`, `npm ci`, `npm run build`, `npm test`, and `cargo test` (1565 passed).
