### PR TITLE
ci: set retention on uploaded workflow artifacts

### DIFF
--- a/.github/workflows/diffscope.yml
+++ b/.github/workflows/diffscope.yml
@@ -91,6 +91,7 @@ jobs:
         if: always() && steps.provider.outputs.configured == 'true'
         uses: actions/upload-artifact@v4
         with:
+          retention-days: 14
           name: diffscope-review-${{ github.event.pull_request.number }}
           path: comments.json
           if-no-files-found: ignore

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -104,6 +104,7 @@ jobs:
         if: ${{ always() && steps.secret-check.outputs.configured == 'true' }}
         uses: actions/upload-artifact@v4
         with:
+          retention-days: 14
           name: eval-reports
           path: |
             eval-current.json


### PR DESCRIPTION
## Summary
- set explicit retention on GitHub Actions upload-artifact steps
- keep CI/release diagnostic artifacts from falling back to repo defaults

## Test plan
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' <changed workflows>
- git diff --check
